### PR TITLE
Update Kia Sportage HEV generations: Added Wikipedia reference and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Kia Sportage HEV
 
+This repository contains signal set configurations for the Kia Sportage HEV, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Kia Sportage HEV.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Kia_Sportage"
+
 generations:
   - name: "First Generation (NQ5)"
     start_year: 2022


### PR DESCRIPTION
- Added references array with Wikipedia article URL
- Updated README.md with standard template documentation
- Verified generation information against Wikipedia article
- Confirmed First Generation (NQ5) with 1.6L turbo hybrid powertrain
